### PR TITLE
make GPUs optional

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -4,7 +4,6 @@
 		"gpu": "optional"
 	},
 	"runArgs": [
-		"--gpus=all",
 		"--privileged"
 	],
 	"mounts": [


### PR DESCRIPTION
This change allows Ona to open the repo on machines that do not have a graphics card. 
Functionality on machines that have a graphics card remains unharmed. 